### PR TITLE
Specify minimum required dependent Fluentd version

### DIFF
--- a/fluent-plugin-remote_syslog.gemspec
+++ b/fluent-plugin-remote_syslog.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit"
   spec.add_development_dependency "test-unit-rr"
 
-  spec.add_runtime_dependency "fluentd"
+  spec.add_runtime_dependency "fluentd", [">= 0.14.0", "< 2"]
   spec.add_runtime_dependency "remote_syslog_sender", ">= 1.1.1"
 end


### PR DESCRIPTION
Because v0.14 API does not have backward compatibility.